### PR TITLE
feat: 채팅 전송 레이트리밋 적용

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/api/response/ErrorCode.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/response/ErrorCode.java
@@ -45,6 +45,8 @@ public enum ErrorCode implements ResponseCode {
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_UNAUTHORIZED", "인증이 필요합니다."),
 	REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_INVALID", "리프레시 토큰이 유효하지 않습니다."),
 	FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_FORBIDDEN", "접근 권한이 없습니다."),
+	TOO_MANY_REQUESTS(
+			HttpStatus.TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", "채팅 요청이 너무 많습니다. 잠시 후 다시 시도해 주세요."),
 	INTERNAL_SERVER_ERROR(
 			HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
 	SERVICE_UNAVAILABLE(

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/config/ChatRateLimitProperties.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/config/ChatRateLimitProperties.java
@@ -1,0 +1,17 @@
+package com.sipomeokjo.commitme.domain.chat.config;
+
+import java.time.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.chat.rate-limit")
+public class ChatRateLimitProperties {
+
+    private boolean enabled = true;
+    private int maxRequests = 20;
+    private Duration window = Duration.ofSeconds(10);
+    private String keyPrefix = ":chat:local:rate-limit:send";
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/service/ChatMessageCommandService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/service/ChatMessageCommandService.java
@@ -47,6 +47,7 @@ public class ChatMessageCommandService {
     private final S3UploadService s3UploadService;
     private final UserRepository userRepository;
     private final ChatMessageMongoMapper chatMessageMongoMapper;
+    private final ChatMessageRateLimiter chatMessageRateLimiter;
     private final Clock clock;
 
     public ChatMessageResponse sendMessage(
@@ -54,6 +55,8 @@ public class ChatMessageCommandService {
         if (userId == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
+        chatMessageRateLimiter.validateSendMessageRateLimit(userId);
+
         Chatroom chatroom =
                 chatroomRepository
                         .findById(chatroomId)

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/service/ChatMessageRateLimiter.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/service/ChatMessageRateLimiter.java
@@ -1,0 +1,54 @@
+package com.sipomeokjo.commitme.domain.chat.service;
+
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
+import com.sipomeokjo.commitme.domain.chat.config.ChatRateLimitProperties;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageRateLimiter {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ChatRateLimitProperties chatRateLimitProperties;
+
+    public void validateSendMessageRateLimit(Long userId) {
+        if (!chatRateLimitProperties.isEnabled() || userId == null) {
+            return;
+        }
+
+        String key = chatRateLimitProperties.getKeyPrefix() + ":" + userId;
+        Duration window = chatRateLimitProperties.getWindow();
+        try {
+            Long count = stringRedisTemplate.opsForValue().increment(key);
+            if (count == null) {
+                return;
+            }
+
+            if (count == 1L) {
+                stringRedisTemplate.expire(key, window);
+            } else {
+                Long ttlSeconds = stringRedisTemplate.getExpire(key);
+                if (ttlSeconds < 0) {
+                    stringRedisTemplate.expire(key, window);
+                }
+            }
+
+            if (count > chatRateLimitProperties.getMaxRequests()) {
+                throw new BusinessException(ErrorCode.TOO_MANY_REQUESTS);
+            }
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn(
+                    "[ChatRateLimit] 제한 검사 실패 userId={} 사유={} (fail-open)",
+                    userId,
+                    e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### Description

짧은 시간동안 너무 많은 채팅을 보내면 채팅 전송을 할 수 없게 합니다.

### Related Issues

- Resolves #4

### Changes Made

1. Redis 기반 고정 윈도우 카운터로 레이트 리밋 구현
2. 10초마다 최대 20개의 메시지 전송 제한

### Testing



### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.